### PR TITLE
Remove dotnet framework dependency

### DIFF
--- a/Rebirth.World/Frames/CharacterFrame.cs
+++ b/Rebirth.World/Frames/CharacterFrame.cs
@@ -12,7 +12,6 @@ using Rebirth.World.Managers;
 using Rebirth.World.Network;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/Rebirth.World/Rebirth.World.csproj
+++ b/Rebirth.World/Rebirth.World.csproj
@@ -23,10 +23,4 @@
     <Folder Include="Tickets\" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Drawing">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\System.Drawing.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I don't think we need .NET framework since we are building a console application.
By using only the .NET core, we could build it for linux and mac.

- remove an unused import of System.Drawing